### PR TITLE
Introduce unsafe views

### DIFF
--- a/src/ArrayViews.jl
+++ b/src/ArrayViews.jl
@@ -12,9 +12,12 @@ end
 export
     StridedArrayView,
     ArrayView,
-    UnsafeArrayView,
     ContiguousView,
     StridedView,
+    UnsafeArrayView,
+    UnsafeContiguousView,
+    UnsafeStridedView,
+
     ContiguousArray,
     ContiguousVector,
     ContiguousMatrix,

--- a/src/ArrayViews.jl
+++ b/src/ArrayViews.jl
@@ -40,4 +40,6 @@ include("contrank.jl")
 include("subviews.jl")
 include("convenience.jl")
 
+include("deprecates.jl")
+
 end  # module ArrayViews

--- a/src/ArrayViews.jl
+++ b/src/ArrayViews.jl
@@ -25,6 +25,7 @@ export
     contiguous_view,
     strided_view,
     view,
+    unsafe_view,
     ellipview,
     diagview,
     rowvec_view,

--- a/src/arrviews.jl
+++ b/src/arrviews.jl
@@ -82,6 +82,7 @@ end
 ### basic methods
 
 parent(a::ArrayView) = a.arr
+parent(a::UnsafeArrayView) = error("Getting parent of an unsafe view is not allowed.")
 
 uget(a::ArrayView, i::Int) = getindex(a.arr, a.offset + i)
 uset!{T}(a::ArrayView{T}, v::T, i::Int) = setindex!(a.arr, v, a.offset + i)

--- a/src/arrviews.jl
+++ b/src/arrviews.jl
@@ -8,13 +8,29 @@ immutable ContiguousView{T,N,Arr<:Array} <: ArrayView{T,N,N}
     shp::NTuple{N,Int}
 end
 
-contiguous_view{T,N}(arr::Array{T}, offset::Int, shp::NTuple{N,Int}) =
+ContiguousView{T,N}(arr::Array{T}, offset::Int, shp::NTuple{N,Int}) =
     ContiguousView{T,N,typeof(arr)}(arr, offset, prod(shp), shp)
 
-contiguous_view(arr::Array, shp::Dims) = contiguous_view(arr, 0, shp)
+ContiguousView(arr::Array, shp::Dims) = ContiguousView(arr, 0, shp)
 
 
-# use StridedView otherwise
+immutable UnsafeContiguousView{T,N} <: UnsafeArrayView{T,N,N}
+    ptr::Ptr{T}
+    len::Int
+    shp::NTuple{N,Int}
+end
+
+UnsafeContiguousView{T,N}(ptr::Ptr{T}, shp::NTuple{N,Int}) =
+    UnsafeContiguousView{T,N}(ptr, prod(shp), shp)
+
+UnsafeContiguousView(arr::Array, shp::Dims) = UnsafeContiguousView(pointer(arr), shp)
+
+UnsafeContiguousView{T,N}(arr::Array{T}, offset::Int, shp::NTuple{N,Int}) =
+    UnsafeContiguousView(pointer(arr, offset+1), shp)
+
+
+
+# use StridedView when contiguousness can not be determined statically
 # condition: M < N
 immutable StridedView{T,N,M,Arr<:Array} <: ArrayView{T,N,M}
     arr::Arr
@@ -24,13 +40,13 @@ immutable StridedView{T,N,M,Arr<:Array} <: ArrayView{T,N,M}
     strides::NTuple{N,Int}
 end
 
-function strided_view{T,N,M}(arr::Array{T}, offset::Int, shp::NTuple{N,Int},
+function StridedView{T,N,M}(arr::Array{T}, offset::Int, shp::NTuple{N,Int},
                              ::Type{ContRank{M}}, strides::NTuple{N,Int})
     @assert M < N
     StridedView{T,N,M,typeof(arr)}(arr, offset, prod(shp), shp, strides)
 end
 
-function strided_view{T,N,M}(arr::Array{T}, shp::NTuple{N,Int},
+function StridedView{T,N,M}(arr::Array{T}, shp::NTuple{N,Int},
                              ::Type{ContRank{M}}, strides::NTuple{N,Int})
     @assert M < N
     StridedView{T,N,M,typeof(arr)}(arr, 0, prod(shp), shp, strides)
@@ -46,5 +62,9 @@ size(a::ArrayView) = a.shp
 uget(a::ArrayView, i::Int) = getindex(a.arr, a.offset + i)
 uset!{T}(a::ArrayView{T}, v::T, i::Int) = setindex!(a.arr, v, a.offset + i)
 
+uget(a::UnsafeArrayView, i::Int) = unsafe_load(a.ptr, i)
+uset!{T}(a::ArrayView{T}, v::T, i::Int) = unsafe_store!(a.ptr, v, i)
+
 offset(a::ArrayView) = a.offset
 pointer(a::ArrayView) = pointer(parent(a), a.offset+1)
+pointer(a::UnsafeArrayView) = a.ptr

--- a/src/arrviews.jl
+++ b/src/arrviews.jl
@@ -13,9 +13,6 @@ contiguous_view{T,N}(arr::Array{T}, offset::Int, shp::NTuple{N,Int}) =
 
 contiguous_view(arr::Array, shp::Dims) = contiguous_view(arr, 0, shp)
 
-contiguous_view(v::ContiguousView, shp::Dims) = contiguous_view(v.arr, v.offset, shp)
-contiguous_view(v::ContiguousView, offset::Int, shp::Dims) = contiguous_view(v.arr, offset + v.offset, shp)
-
 
 # use StridedView otherwise
 # condition: M < N

--- a/src/common.jl
+++ b/src/common.jl
@@ -44,6 +44,9 @@ contiguousrank{T,N,M}(a::StridedArrayView{T,N,M}) = M
 contrank{T,N}(a::Array{T,N}) = ContRank{N}
 contrank{T,N,M}(a::StridedArrayView{T,N,M}) = ContRank{M}
 
+length(a::StridedArrayView) = a.len
+size(a::StridedArrayView) = a.shp
+
 getdim{N}(s::NTuple{N,Int}, d::Integer) = (1 <= d <= N ? s[d] : 1)
 size{T,N}(a::StridedArrayView{T,N}, d::Integer) = getdim(size(a), d)
 

--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -6,7 +6,7 @@ function diagview{T}(a::DenseArray{T,2})
     m, n = size(a)
     s1, s2 = strides(a)
     len = min(m, n)
-    strided_view(parent(a), offset(a), (len,), ContRank{0}, (s1 + s2,))
+    StridedView(parent(a), offset(a), (len,), ContRank{0}, (s1 + s2,))
 end
 
 ## row vector view
@@ -14,20 +14,20 @@ end
 function rowvec_view{T}(a::DenseArray{T,2}, i::Integer)
     m, n = size(a)
     s1, s2 = strides(a)
-    strided_view(parent(a), offset(a) + (i-1) * s1, (n,), ContRank{0}, (s2,))
+    StridedView(parent(a), offset(a) + (i-1) * s1, (n,), ContRank{0}, (s2,))
 end
 
 ## flatten_view
 
 flatten_view(a::ContiguousArray) =
-    contiguous_view(parent(a), offset(a), (length(a),))
+    ContiguousView(parent(a), offset(a), (length(a),))
 
 
 ## reshape_view
 
 function reshape_view{N}(a::ContiguousArray, shp::NTuple{N,Int})
     prod(shp) == length(a) || throw(DimensionMismatch("Inconsistent array size."))
-    contiguous_view(parent(a), offset(a), shp)
+    ContiguousView(parent(a), offset(a), shp)
 end
 
 ## ellipview

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,0 +1,2 @@
+Base.@deprecate contiguous_view ContiguousView
+Base.@deprecate strided_view StridedView

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -1,7 +1,7 @@
 # layout-related functions
 
-typealias ContViews{T,N} ContiguousView{T,N}
-typealias NonContViews{T,N,M} StridedView{T,N,M}
+typealias ContViews{T,N} Union(ContiguousView{T,N},UnsafeContiguousView{T,N})
+typealias NonContViews{T,N,M} Union(StridedView{T,N,M}, UnsafeStridedView{T,N,M})
 
 typealias ContiguousArray{T,N} Union(Array{T,N}, ContiguousView{T,N})
 typealias ContiguousVector{T} ContiguousArray{T,1}

--- a/src/subviews.jl
+++ b/src/subviews.jl
@@ -282,6 +282,40 @@ make_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Sub
 make_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs, i4::Subs, i5::Subs, I::Subs...) =
     StridedView(parent(a), aoffset(a, i1, i2, i3, i4, i5, I...), shp, cr, vstrides(a, i1, i2, i3, i4, i5, I...))
 
+
+make_unsafe_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i::Subs) =
+    UnsafeContiguousView(parent(a), aoffset(a, i), shp)
+
+make_unsafe_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs) =
+    UnsafeContiguousView(parent(a), aoffset(a, i1, i2), shp)
+
+make_unsafe_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs) =
+    UnsafeContiguousView(parent(a), aoffset(a, i1, i2, i3), shp)
+
+make_unsafe_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs, i4::Subs) =
+    UnsafeContiguousView(parent(a), aoffset(a, i1, i2, i3, i4), shp)
+
+make_unsafe_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs, i4::Subs, i5::Subs, I::Subs...) =
+    UnsafeContiguousView(parent(a), aoffset(a, i1, i2, i3, i4, i5, I...), shp)
+
+make_unsafe_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i::Subs) =
+    UnsafeStridedView(parent(a), aoffset(a, i), shp, cr, vstrides(a, i))
+
+make_unsafe_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs) =
+    UnsafeStridedView(parent(a), aoffset(a, i1, i2), shp, cr, vstrides(a, i1, i2))
+
+make_unsafe_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs) =
+    UnsafeStridedView(parent(a), aoffset(a, i1, i2, i3), shp, cr, vstrides(a, i1, i2, i3))
+
+make_unsafe_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs, i4::Subs) =
+    UnsafeStridedView(parent(a), aoffset(a, i1, i2, i3, i4), shp, cr, vstrides(a, i1, i2, i3, i4))
+
+make_unsafe_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs, i4::Subs, i5::Subs, I::Subs...) =
+    UnsafeStridedView(parent(a), aoffset(a, i1, i2, i3, i4, i5, I...), shp, cr, vstrides(a, i1, i2, i3, i4, i5, I...))
+
+
+##### Interface
+
 view(a::Array) = ContiguousView(a, size(a))
 view(a::ArrayView) = a
 
@@ -300,3 +334,23 @@ view(a::DenseArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs) =
 view(a::DenseArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs, i5::Subs, I::Subs...) =
     (shp = vshape(a, i1, i2, i3, i4, i5, I...);
      make_view(a, restrict_crank(acontrank(a, i1, i2, i3, i4, i5, I...), shp), shp, i1, i2, i3, i4, i5, I...))
+
+
+unsafe_view(a::Array) = ContiguousView(a, size(a))
+unsafe_view(a::ArrayView) = a
+
+unsafe_view(a::DenseArray, i::Subs) =
+    (shp = vshape(a, i); make_unsafe_view(a, restrict_crank(acontrank(a, i), shp), shp, i))
+
+unsafe_view(a::DenseArray, i1::Subs, i2::Subs) =
+    (shp = vshape(a, i1, i2); make_unsafe_view(a, restrict_crank(acontrank(a, i1, i2), shp), shp, i1, i2))
+
+unsafe_view(a::DenseArray, i1::Subs, i2::Subs, i3::Subs) =
+    (shp = vshape(a, i1, i2, i3); make_unsafe_view(a, restrict_crank(acontrank(a, i1, i2, i3), shp), shp, i1, i2, i3))
+
+unsafe_view(a::DenseArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs) =
+    (shp = vshape(a, i1, i2, i3, i4); make_unsafe_view(a, restrict_crank(acontrank(a, i1, i2, i3, i4), shp), shp, i1, i2, i3, i4))
+
+unsafe_view(a::DenseArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs, i5::Subs, I::Subs...) =
+    (shp = vshape(a, i1, i2, i3, i4, i5, I...);
+     make_unsafe_view(a, restrict_crank(acontrank(a, i1, i2, i3, i4, i5, I...), shp), shp, i1, i2, i3, i4, i5, I...))

--- a/src/subviews.jl
+++ b/src/subviews.jl
@@ -253,36 +253,36 @@ _vstrides{N}(ss::NTuple{N,Int}, k::Int, i1::Subs, i2::Subs, i3::Subs, I::Subs...
 ##### View construction ######
 
 make_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i::Subs) =
-    contiguous_view(parent(a), aoffset(a, i), shp)
+    ContiguousView(parent(a), aoffset(a, i), shp)
 
 make_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs) =
-    contiguous_view(parent(a), aoffset(a, i1, i2), shp)
+    ContiguousView(parent(a), aoffset(a, i1, i2), shp)
 
 make_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs) =
-    contiguous_view(parent(a), aoffset(a, i1, i2, i3), shp)
+    ContiguousView(parent(a), aoffset(a, i1, i2, i3), shp)
 
 make_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs, i4::Subs) =
-    contiguous_view(parent(a), aoffset(a, i1, i2, i3, i4), shp)
+    ContiguousView(parent(a), aoffset(a, i1, i2, i3, i4), shp)
 
 make_view{N}(a::DenseArray, cr::Type{ContRank{N}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs, i4::Subs, i5::Subs, I::Subs...) =
-    contiguous_view(parent(a), aoffset(a, i1, i2, i3, i4, i5, I...), shp)
+    ContiguousView(parent(a), aoffset(a, i1, i2, i3, i4, i5, I...), shp)
 
 make_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i::Subs) =
-    strided_view(parent(a), aoffset(a, i), shp, cr, vstrides(a, i))
+    StridedView(parent(a), aoffset(a, i), shp, cr, vstrides(a, i))
 
 make_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs) =
-    strided_view(parent(a), aoffset(a, i1, i2), shp, cr, vstrides(a, i1, i2))
+    StridedView(parent(a), aoffset(a, i1, i2), shp, cr, vstrides(a, i1, i2))
 
 make_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs) =
-    strided_view(parent(a), aoffset(a, i1, i2, i3), shp, cr, vstrides(a, i1, i2, i3))
+    StridedView(parent(a), aoffset(a, i1, i2, i3), shp, cr, vstrides(a, i1, i2, i3))
 
 make_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs, i4::Subs) =
-    strided_view(parent(a), aoffset(a, i1, i2, i3, i4), shp, cr, vstrides(a, i1, i2, i3, i4))
+    StridedView(parent(a), aoffset(a, i1, i2, i3, i4), shp, cr, vstrides(a, i1, i2, i3, i4))
 
 make_view{M,N}(a::DenseArray, cr::Type{ContRank{M}}, shp::NTuple{N,Int}, i1::Subs, i2::Subs, i3::Subs, i4::Subs, i5::Subs, I::Subs...) =
-    strided_view(parent(a), aoffset(a, i1, i2, i3, i4, i5, I...), shp, cr, vstrides(a, i1, i2, i3, i4, i5, I...))
+    StridedView(parent(a), aoffset(a, i1, i2, i3, i4, i5, I...), shp, cr, vstrides(a, i1, i2, i3, i4, i5, I...))
 
-view(a::Array) = contiguous_view(a, size(a))
+view(a::Array) = ContiguousView(a, size(a))
 view(a::ArrayView) = a
 
 view(a::DenseArray, i::Subs) =

--- a/test/arrviews.jl
+++ b/test/arrviews.jl
@@ -130,7 +130,7 @@ end
 
 function verify_cview{T,N}(src::Array{T}, o::Int, siz::NTuple{N,Int})
     @assert o + prod(siz) <= length(src)
-    v = contiguous_view(src, o, siz)
+    v = ContiguousView(src, o, siz)
     @test isa(v, ContiguousView{T,N})
     @test eltype(v) == T
     @test ndims(v) == N
@@ -168,7 +168,7 @@ function verify_sview{T,N,M}(src::Array{T}, o::Int, siz::NTuple{N,Int}, cr::Type
     end
 
     @assert o + ss[N] * siz[N]  <= length(src)
-    v = strided_view(src, o, siz, cr, ss)
+    v = StridedView(src, o, siz, cr, ss)
     @test isa(v, StridedView{T,N,M})
     @test eltype(v) == T
     @test ndims(v) == N

--- a/test/benchmark_construct.jl
+++ b/test/benchmark_construct.jl
@@ -2,82 +2,84 @@
 
 using ArrayViews
 
-function traverse_row_subs(a::Array)
+function traverse_row_subs(a::Array, r::Int)
     m = size(a, 1)
-    for i = 1:m
+    for _ = 1:r, i = 1:m
         sub(a, i, :)
     end
 end
 
-function traverse_row_views(a::Array)
+function traverse_row_views(a::Array, r::Int)
     m = size(a, 1)
-    for i = 1:m
+    for _ = 1:r, i = 1:m
         view(a, i, :)
     end
 end
 
-function traverse_column_subs(a::Array)
+function traverse_row_unsafeviews(a::Array, r::Int)
+    m = size(a, 1)
+    for _ = 1:r, i = 1:m
+        unsafe_view(a, i, :)
+    end
+end
+
+function traverse_column_subs(a::Array, r::Int)
     n = size(a, 2)
-    for i = 1:n
+    for _ = 1:r, i = 1:n
         sub(a, :, i)
     end
 end
 
-function traverse_column_views(a::Array)
+function traverse_column_views(a::Array, r::Int)
     n = size(a, 2)
-    for i = 1:n
+    for _ = 1:r, i = 1:n
         view(a, :, i)
     end
 end
 
-function traverse_page_subs(a::Array)
-    n = size(a, 3)
-    for i = 1:n
-        sub(a, :, :, i)
+function traverse_column_unsafeviews(a::Array, r::Int)
+    n = size(a, 2)
+    for _ = 1:r, i = 1:n
+        unsafe_view(a, :, i)
     end
 end
 
-function traverse_page_views(a::Array)
-    n = size(a, 3)
-    for i = 1:n
-        view(a, :, :, i)
-    end
-end
 
 ## data
 
 const a1 = rand(1000, 5)
 const a2 = rand(5, 1000)
-const a3 = rand(2, 3, 1000)
 
 # traverse rows
 
-traverse_row_subs(a1)
-traverse_row_views(a1)
+traverse_row_subs(a1, 10)
+traverse_row_views(a1, 10)
+traverse_row_unsafeviews(a1, 10)
 
-et1 = @elapsed for t = 1:1000; traverse_row_subs(a1); end
-et2 = @elapsed for t = 1:1000; traverse_row_views(a1); end
+et1 = @elapsed traverse_row_subs(a1, 1000)
+et2 = @elapsed traverse_row_views(a1, 1000)
+et3 = @elapsed traverse_row_unsafeviews(a1, 1000)
 
-@printf("Traverse Rows:  subs => %7.4f sec    views => %7.4f sec  |  gain = %6.3fx\n", et1, et2, et1 / et2)
+m1 = 1.0 / et1
+m2 = 1.0 / et2
+m3 = 1.0 / et3
+
+@printf("Traverse Rows:  subs => %7.4f M/sec   views => %7.4f M/sec (%6.3fx)   unsafe_views => %7.4f M/sec (%6.3fx)\n",
+    m1, m2, m2 / m1, m3, m3 / m1)
 
 # traverse cols
 
-traverse_column_subs(a2)
-traverse_column_views(a2)
+traverse_column_subs(a2, 10)
+traverse_column_views(a2, 10)
+traverse_column_unsafeviews(a2, 10)
 
-et1 = @elapsed for t = 1:1000; traverse_column_subs(a2); end
-et2 = @elapsed for t = 1:1000; traverse_column_views(a2); end
+et1 = @elapsed traverse_column_subs(a2, 1000)
+et2 = @elapsed traverse_column_views(a2, 1000)
+et3 = @elapsed traverse_column_unsafeviews(a2, 1000)
 
-@printf("Traverse Cols:  subs => %7.4f sec    views => %7.4f sec  |  gain = %6.3fx\n", et1, et2, et1 / et2)
+m1 = 1.0 / et1
+m2 = 1.0 / et2
+m3 = 1.0 / et3
 
-# traverse pages
-
-traverse_page_subs(a3)
-traverse_page_views(a3)
-
-et1 = @elapsed for t = 1:1000; traverse_page_subs(a3); end
-et2 = @elapsed for t = 1:1000; traverse_page_views(a3); end
-
-@printf("Traverse Pages: subs => %7.4f sec    views => %7.4f sec  |  gain = %6.3fx\n", et1, et2, et1 / et2)
-
-
+@printf("Traverse Cols:  subs => %7.4f M/sec   views => %7.4f M/sec (%6.3fx)   unsafe_views => %7.4f M/sec (%6.3fx)\n",
+    m1, m2, m2 / m1, m3, m3 / m1)


### PR DESCRIPTION
Unsafe views maintains a raw pointer to the base address instead of the underlying array itself. It should only be used within a local scope.