### PR TITLE
Fix test for array indexing breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,7 @@ julia:
    - 0.3
    - 0.4
    - nightly
-before_install:
-   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-   - julia -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd());'
-   - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'Pkg.test("ArrayViews", coverage=true)'; fi
-   - if [ $TRAVIS_JULIA_VERSION = "release" ]; then julia -e 'Pkg.test("ArrayViews")'; fi
 after_success:
-   - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'cd(Pkg.dir("ArrayViews")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
+   - if [ $TRAVIS_JULIA_VERSION != "0.3" ]; then julia -e 'cd(Pkg.dir("ArrayViews")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
 notifications:
   email: false

--- a/test/subviews.jl
+++ b/test/subviews.jl
@@ -30,8 +30,14 @@ function _test_arrview(a, r, subs...)
     _test_arrview_contents(unsafe_view(a, subs...), r)
 end
 
-macro test_arrview(a_, subs...)
-    esc(:(_test_arrview($a_, ($a_)[$(subs...)], $(subs...))))
+if VERSION >= v"0.4"
+    macro test_arrview(a_, subs...)
+        esc(:(_test_arrview($a_, sub($a_, $(subs...)), $(subs...))))
+    end
+else
+    macro test_arrview(a_, subs...)
+        esc(:(_test_arrview($a_, $a_[$(subs...)], $(subs...))))
+    end
 end
 
 #### test views from arrays


### PR DESCRIPTION
This keeps the behavior of `view` and only updates the test to check if the schematics is the same with `sub`. Given [base provides both `sub` and `slice`](https://github.com/JuliaLang/julia/pull/13612#issuecomment-156888466) I guess it's fine to stick to the current behavior?

Also clean up and fix `.travis.yml` so that it is actually running the tests on `0.3` and `0.4` .......
