### PR TITLE
Faster Contigous Views of 4D Arrays

### DIFF
--- a/src/ArrayViews.jl
+++ b/src/ArrayViews.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
+VERSION >= v"0.4.0-dev+6521" && __precompile__(false)
 
 module ArrayViews
 

--- a/src/ArrayViews.jl
+++ b/src/ArrayViews.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__(false)
+VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
 
 module ArrayViews
 

--- a/src/subviews.jl
+++ b/src/subviews.jl
@@ -120,11 +120,9 @@ function roffset(a::ContiguousArray, i1::Colon, i2::Colon, i3::Subs, i4::Subs)
     return o
 end
 
-
 # General
 
 roffset(a::ContiguousArray, i1::Colon, i2::Colon, i3::Colon, i4::Colon, I::Colon...) = 0
-
 
 function roffset(a::ContiguousArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs, I::Subs...)
     o = _offset(i1)
@@ -132,7 +130,6 @@ function roffset(a::ContiguousArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs, I::
     o += s * _offset(i2)
     o += (s *= size(a,2)) * _offset(i3)
     o += (s *= size(a,3)) * _offset(i4)
-#    o += (s *= size(a,4)) * _offset(i5)
     for i = 1:length(I)
         o += (s *= size(a,i+3)) * _offset(I[i])
     end

--- a/src/subviews.jl
+++ b/src/subviews.jl
@@ -94,6 +94,32 @@ roffset{T}(a::StridedArray{T,3}, i1::SubsNC, i2::SubsNC, i3::Colon) =
 roffset{T}(a::StridedArray{T,3}, i1::SubsNC, i2::SubsNC, i3::SubsNC) =
     _offset(i1) * stride(a,1) + _offset(i2) * stride(a,2) + _offset(i3) * stride(a,3)
 
+# 4D (parial)
+function roffset(a::ContiguousArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs)
+    o = _offset(i1)
+    s = size(a,1)
+    o += s * _offset(i2)
+    o += (s *= size(a,2)) * _offset(i3)
+    o += (s *= size(a,3)) * _offset(i4)
+    return o
+end
+
+function roffset(a::ContiguousArray, i1::Colon, i2::Subs, i3::Subs, i4::Subs)
+    s = size(a,1)
+    o = s * _offset(i2)
+    o += (s *= size(a,2)) * _offset(i3)
+    o += (s *= size(a,3)) * _offset(i4)
+    return o
+end
+
+function roffset(a::ContiguousArray, i1::Colon, i2::Colon, i3::Subs, i4::Subs)
+    s = size(a,1)
+    o = (s *= size(a,2)) * _offset(i3)
+    o += (s *= size(a,3)) * _offset(i4)
+    return o
+end
+
+
 # General
 
 roffset(a::ContiguousArray, i1::Colon, i2::Colon, i3::Colon, i4::Colon, I::Colon...) = 0
@@ -104,10 +130,11 @@ function roffset(a::ContiguousArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs, I::
     o += s * _offset(i2)
     o += (s *= size(a,2)) * _offset(i3)
     o += (s *= size(a,3)) * _offset(i4)
+#    o += (s *= size(a,4)) * _offset(i5)
     for i = 1:length(I)
         o += (s *= size(a,i+3)) * _offset(I[i])
     end
-    return o::Int
+    return o
 end
 
 roffset(a::StridedArray, i1::Subs, i2::Subs, i3::Subs, I::Subs...) =
@@ -118,7 +145,7 @@ function _roffset{N}(ss::NTuple{N,Int}, subs::NTuple{N})
     for i = 2:N
         o += _offset(subs[i]) * ss[i]
     end
-    return o::Int
+    return o
 end
 
 

--- a/src/subviews.jl
+++ b/src/subviews.jl
@@ -95,7 +95,7 @@ roffset{T}(a::StridedArray{T,3}, i1::SubsNC, i2::SubsNC, i3::SubsNC) =
     _offset(i1) * stride(a,1) + _offset(i2) * stride(a,2) + _offset(i3) * stride(a,3)
 
 
-# 4D (parial)
+# 4D (partial)
 function roffset(a::ContiguousArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs)
     o = _offset(i1)
     s = size(a,1)

--- a/src/subviews.jl
+++ b/src/subviews.jl
@@ -94,6 +94,7 @@ roffset{T}(a::StridedArray{T,3}, i1::SubsNC, i2::SubsNC, i3::Colon) =
 roffset{T}(a::StridedArray{T,3}, i1::SubsNC, i2::SubsNC, i3::SubsNC) =
     _offset(i1) * stride(a,1) + _offset(i2) * stride(a,2) + _offset(i3) * stride(a,3)
 
+
 # 4D (parial)
 function roffset(a::ContiguousArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs)
     o = _offset(i1)
@@ -123,6 +124,7 @@ end
 # General
 
 roffset(a::ContiguousArray, i1::Colon, i2::Colon, i3::Colon, i4::Colon, I::Colon...) = 0
+
 
 function roffset(a::ContiguousArray, i1::Subs, i2::Subs, i3::Subs, i4::Subs, I::Subs...)
     o = _offset(i1)

--- a/test/subviews.jl
+++ b/test/subviews.jl
@@ -213,6 +213,30 @@ avparent = reshape(1.:1680., (8, 7, 6, 5))
 @test_arrview(avparent, 1:2:7, :,   3:5, 2:5)
 @test_arrview(avparent, 1:2:7, :, 1:2:5, 2:5)
 
+@test_arrview(avparent, :, 1, 1, 1)
+@test_arrview(avparent, :, 1, 2, 1)
+@test_arrview(avparent, :, :, 2, 2)
+@test_arrview(avparent, :, :, 1:2, 3:4)
+
+
+# Some 5D tests
+avparent2 = reshape(1.:6720., (8, 7, 6, 5, 4))
+
+@test_arrview(avparent2, :, 1, 1, 1, 1)
+@test_arrview(avparent2, :, 1, 1, 3, 1)
+@test_arrview(avparent2, :, 1, 2, 3, 3:4)
+@test_arrview(avparent2, 2:7, 1, 1, 1, 3:4)
+
+@test_arrview(avparent2, 1, :, 1, 3, 4)
+@test_arrview(avparent2, 2, 3, :, 3, 4)
+@test_arrview(avparent2, 3, 4, 5, :, 4)
+@test_arrview(avparent2, 2, 3, 4, 4, :)
+
+@test_arrview(avparent2, 1, 2:3, 3, 4, 2)
+@test_arrview(avparent2, 2, 1, 3:4, 1, 1)
+@test_arrview(avparent2, 3, 1, 1, 4:5, 2)
+@test_arrview(avparent2, 4, 1, 1, 3:4, 2:4)
+
 #### Test Subviews of Views
 
 function print_subscripts(subs1, subs2)


### PR DESCRIPTION
This adds some `roffset` methods for 4D arrays.  This makes constructing an contiguous `unsafe_view` of a 4D array roughly 2.5x faster.

Using the benchmark [here](https://github.com/JaredCrean2/julia_tests/tree/master/array_speed4): 

before:
```
  0.892318 seconds (35.97 M allocations: 548.845 MB, 2.38% gc time)
```
after:   
```
  0.332585 seconds
```